### PR TITLE
Add missing roland dependency to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ seaborn
 deepsnap
 tensorboardX
 tensorboard
+git+https://github.com/dnidever/roland


### PR DESCRIPTION
This PR adds the roland package to the requirements.txt file.